### PR TITLE
add: サンプルデータに複数時代のデータとeraプロパティを追加

### DIFF
--- a/src/lib/components/Timeline.svelte
+++ b/src/lib/components/Timeline.svelte
@@ -1,41 +1,98 @@
 <!-- Timeline.svelte -->
 <script lang="ts">
-  import type { TimelineItem } from '../types/timeline';
+  import { onMount } from 'svelte';
   import { slide } from 'svelte/transition';
+  import type { TimelineItem } from '../types/timeline';
 
   export let items: TimelineItem[] = [];
+
+  // eraごとにグループ化
+  $: grouped = (() => {
+    if (!items || items.length === 0) return [];
+    const map = new Map<string, TimelineItem[]>();
+    for (const item of items) {
+      const era = item.era || 'その他';
+      if (!map.has(era)) map.set(era, []);
+      map.get(era)?.push(item);
+    }
+    return Array.from(map, ([era, items]) => ({ era, items }));
+  })();
+
+  // 背景色マップ（必要に応じて追加・変更可）
+  const eraBgMap: Record<string, string> = {
+    'ルネサンス': 'bg-blue-50',
+    'ポスト印象派': 'bg-yellow-50',
+    'その他': 'bg-gray-50',
+  };
+
+  let currentEra: string = 'その他';
+  $: if (grouped && grouped.length > 0) currentEra = grouped[0].era;
+  let eraRefs = [];
+
+  onMount(() => {
+    if (typeof window === 'undefined') return;
+    const onScroll = () => {
+      if (!eraRefs || eraRefs.length === 0) return;
+      const center = window.innerHeight * 0.35;
+      const visible = eraRefs
+        .map((el, idx) => ({
+          era: grouped[idx]?.era ?? 'その他',
+          top: el?.getBoundingClientRect().top ?? Infinity
+        }))
+        .filter(({ top }) => top < center && top > 0);
+      if (visible.length > 0) {
+        visible.sort((a, b) => a.top - b.top);
+        currentEra = visible[0].era;
+      } else {
+        currentEra = grouped[0]?.era ?? 'その他';
+      }
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener('scroll', onScroll);
+  });
 </script>
 
-<div class="w-full max-w-6xl mx-auto px-2 sm:px-4 md:px-8">
+<div class={`w-full max-w-6xl mx-auto px-2 sm:px-4 md:px-8 transition-colors duration-500 ${eraBgMap[currentEra] || 'bg-gray-50'}`}>  
   <div class="relative py-8">
     <!-- timeline vertical line -->
     <div
       class="hidden sm:block absolute left-1/2 h-full w-0.5 bg-gray-200 transform -translate-x-1/2"
     ></div>
-    {#each items as item}
-      <div class="flex flex-col sm:flex-row justify-between mb-8 relative" transition:slide={{ duration: 400 }}>
-        <!-- インジケーター（丸ドット）: sm以上で中央線上に表示 -->
-        <div class="hidden sm:block absolute left-1/2 top-6 -translate-x-1/2 w-4 h-4 bg-blue-500 border-4 border-white rounded-full z-20 shadow"></div>
-        <!-- 日付 -->
-        <div class="sm:w-32 text-right sm:pr-8 text-gray-600 flex-shrink-0 mb-2 sm:mb-0">
-          {item.date}
-        </div>
-        <!-- コンテンツカード -->
-        <div
-          class="flex-1 max-w-full sm:max-w-[calc(50%-4rem)] sm:ml-8 p-4 bg-white rounded-lg shadow-md"
-        >
-          <h3 class="text-lg sm:text-xl font-medium text-gray-800 mb-2">{item.title}</h3>
-          <p class="text-gray-600 mb-4">{item.description}</p>
-          {#if item.image}
-            <img src={item.image} alt={item.title} class="w-full rounded-md mb-4" />
-          {/if}
-          {#if item.category}
-            <span class="inline-block px-2 py-1 bg-gray-100 rounded text-sm text-gray-600"
-              >{item.category}</span
-            >
-          {/if}
-        </div>
+    {#each grouped as group, i (group.era)}
+      <!-- 時代区分見出し -->
+      <div
+        bind:this={eraRefs[i]}
+        data-era={group.era}
+        class="relative z-10 text-center font-bold text-xl sm:text-2xl text-blue-700 mb-8 mt-12 sm:mt-16 tracking-wide"
+      >
+        {group.era}
       </div>
+      {#each group.items as item}
+        <div class="flex flex-col sm:flex-row justify-between mb-8 relative" transition:slide={{ duration: 400 }}>
+          <!-- インジケーター（丸ドット）: sm以上で中央線上に表示 -->
+          <div class="hidden sm:block absolute left-1/2 top-6 -translate-x-1/2 w-4 h-4 bg-blue-500 border-4 border-white rounded-full z-20 shadow"></div>
+          <!-- 日付 -->
+          <div class="sm:w-32 text-right sm:pr-8 text-gray-600 flex-shrink-0 mb-2 sm:mb-0">
+            {item.date}
+          </div>
+          <!-- コンテンツカード -->
+          <div
+            class="flex-1 max-w-full sm:max-w-[calc(50%-4rem)] sm:ml-8 p-4 bg-white rounded-lg shadow-md"
+          >
+            <h3 class="text-lg sm:text-xl font-medium text-gray-800 mb-2">{item.title}</h3>
+            <p class="text-gray-600 mb-4">{item.description}</p>
+            {#if item.image}
+              <img src={item.image} alt={item.title} class="w-full rounded-md mb-4" />
+            {/if}
+            {#if item.category}
+              <span class="inline-block px-2 py-1 bg-gray-100 rounded text-sm text-gray-600"
+                >{item.category}</span
+              >
+            {/if}
+          </div>
+        </div>
+      {/each}
     {/each}
   </div>
 </div>

--- a/src/lib/data/sampleData.ts
+++ b/src/lib/data/sampleData.ts
@@ -8,7 +8,8 @@ export const timelineData: TimelineItem[] = [
       'レオナルド・ダ・ヴィンチによって描かれた肖像画。現在はルーブル美術館に所蔵されている。',
     category: '絵画',
     image:
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/Mona_Lisa%2C_by_Leonardo_da_Vinci%2C_from_C2RMF_retouched.jpg/687px-Mona_Lisa%2C_by_Leonardo_da_Vinci%2C_from_C2RMF_retouched.jpg'
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/Mona_Lisa%2C_by_Leonardo_da_Vinci%2C_from_C2RMF_retouched.jpg/687px-Mona_Lisa%2C_by_Leonardo_da_Vinci%2C_from_C2RMF_retouched.jpg',
+    era: 'ルネサンス'
   },
   {
     date: '1889',
@@ -17,6 +18,37 @@ export const timelineData: TimelineItem[] = [
       'フィンセント・ファン・ゴッホによって描かれた油彩画。現在はニューヨーク近代美術館に所蔵されている。',
     category: '絵画',
     image:
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg/1280px-Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg'
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg/1280px-Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg',
+    era: 'ポスト印象派'
+  },
+  {
+    date: '1937',
+    title: 'ゲルニカ',
+    description:
+      'パブロ・ピカソによるスペイン内戦をテーマにした大作。現在はソフィア王妃芸術センターに所蔵。',
+    category: '絵画',
+    image:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/PicassoGuernica.jpg/800px-PicassoGuernica.jpg',
+    era: 'その他'
+  },
+  {
+    date: '1305',
+    title: 'スクロヴェーニ礼拝堂のフレスコ画',
+    description:
+      'ジョットによるイタリア初期ルネサンスの代表的な壁画。パドヴァのスクロヴェーニ礼拝堂に現存。',
+    category: '壁画',
+    image:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/Giotto_-_Scrovegni_Chapel_-_Padua_Italy.jpg/800px-Giotto_-_Scrovegni_Chapel_-_Padua_Italy.jpg',
+    era: 'ルネサンス'
+  },
+  {
+    date: '1872',
+    title: '印象・日の出',
+    description:
+      'クロード・モネによる印象派の代表作。フランスのマルモッタン美術館に所蔵。',
+    category: '絵画',
+    image:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Claude_Monet%2C_Impression%2C_soleil_levant.jpg/800px-Claude_Monet%2C_Impression%2C_soleil_levant.jpg',
+    era: 'その他'
   }
 ];

--- a/src/lib/types/timeline.ts
+++ b/src/lib/types/timeline.ts
@@ -4,4 +4,5 @@ export interface TimelineItem {
   description: string;
   category?: string;
   image?: string;
+  era?: string;
 }


### PR DESCRIPTION
サンプルデータ（sampleData.ts）を拡充し、ルネサンス・ポスト印象派・その他など複数時代のデータを5件追加しました。
また、TimelineItem型にeraプロパティを追加しています。