### PR TITLE
feat: F1-2 特定時代（ルネサンス期）限定表示フィルタを追加

### DIFF
--- a/src/lib/components/Timeline.svelte
+++ b/src/lib/components/Timeline.svelte
@@ -12,12 +12,16 @@
   }
 
   export let items: TimelineItem[] = [];
+  // フェーズ1-2: 特定時代フィルタ（デフォルト：ルネサンス）
+  export let filterEra: string = 'ルネサンス';
+  let filteredItems: TimelineItem[] = [];
+  $: filteredItems = items.filter(item => item.era === filterEra);
 
   // eraごとにグループ化
   $: grouped = (() => {
-    if (!items || items.length === 0) return [];
+    if (!filteredItems || filteredItems.length === 0) return [];
     const map = new Map<string, TimelineItem[]>();
-    for (const item of items) {
+    for (const item of filteredItems) {
       const era = item.era || 'その他';
       if (!map.has(era)) map.set(era, []);
       map.get(era)?.push(item);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,5 +7,5 @@
   <h1 class="text-2xl sm:text-3xl md:text-4xl font-bold text-gray-800 text-center py-8">
     芸術作品の歴史タイムライン
   </h1>
-  <Timeline items={timelineData} />
+  <Timeline items={timelineData} filterEra="ルネサンス" />
 </main>


### PR DESCRIPTION
- `filterEra` プロパティを追加し、デフォルトで “ルネサンス” のみ表示
- `filteredItems` 経由でアイテムをフィルタリングし、グループ化処理を更新

closes #15