### PR TITLE
update: F2-1 対象時代範囲フィルタと中世データ追加

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,9 +11,13 @@ export default [
   },
   {
     languageOptions: {
+      env: { browser: true },
       globals: {
         console: true,
-        document: true
+        document: true,
+        window: true,
+        HTMLElement: true,
+        IntersectionObserver: true
       }
     }
   },

--- a/src/lib/components/Timeline.svelte
+++ b/src/lib/components/Timeline.svelte
@@ -12,10 +12,14 @@
   }
 
   export let items: TimelineItem[] = [];
-  // フェーズ1-2: 特定時代フィルタ（デフォルト：ルネサンス）
-  export let filterEra: string = 'ルネサンス';
+  // フェーズ2-1: 年代範囲フィルタ（例：476年〜1600年）
+  export let startYear: number = 476;
+  export let endYear: number = 1600;
   let filteredItems: TimelineItem[] = [];
-  $: filteredItems = items.filter(item => item.era === filterEra);
+  $: filteredItems = items.filter(item => {
+    const year = parseInt(item.date, 10);
+    return !isNaN(year) && year >= startYear && year <= endYear;
+  });
 
   // eraごとにグループ化
   $: grouped = (() => {
@@ -31,6 +35,7 @@
 
   // 背景色マップ（必要に応じて追加・変更可）
   const eraBgMap: Record<string, string> = {
+    '中世': 'bg-green-50',
     'ルネサンス': 'bg-blue-50',
     'ポスト印象派': 'bg-yellow-50',
     'その他': 'bg-gray-50',

--- a/src/lib/data/sampleData.ts
+++ b/src/lib/data/sampleData.ts
@@ -166,5 +166,12 @@ export const timelineData: TimelineItem[] = [
     description: '二月革命と十月革命によりロシア帝政が崩壊し、ソビエト政権が成立。',
     category: '歴史',
     era: 'その他'
+  },
+  {
+    date: '476',
+    title: '西ローマ帝国滅亡',
+    description: '西ローマ帝国が滅亡し、西ヨーロッパは中世に入る。',
+    category: '歴史',
+    era: '中世'
   }
 ];


### PR DESCRIPTION
- Timelineコンポーネントに開始年(startYear)と終了年(endYear)のプロップを追加し、指定範囲でアイテムをフィルタリング
- sampleData.tsに中世イベント（西ローマ帝国滅亡）を追加
- ESLint設定を調整 (browser globals)