### PR TITLE
fix: イベントを年代順にソートするように修正

### DIFF
--- a/src/lib/components/Timeline.svelte
+++ b/src/lib/components/Timeline.svelte
@@ -15,7 +15,7 @@
   // フェーズ1-2: 特定時代フィルタ（デフォルト：ルネサンス）
   export let filterEra: string = 'ルネサンス';
   let filteredItems: TimelineItem[] = [];
-  $: filteredItems = items.filter(item => item.era === filterEra);
+  $: filteredItems = items.filter(item => item.era === filterEra).sort((a, b) => parseInt(a.date, 10) - parseInt(b.date, 10));
 
   // eraごとにグループ化
   $: grouped = (() => {

--- a/src/lib/components/Timeline.svelte
+++ b/src/lib/components/Timeline.svelte
@@ -96,8 +96,8 @@
             <div class="flex flex-col sm:flex-row-reverse justify-between mb-8 relative" in:slide={{ duration: 400 }}>
               <!-- インジケーター（丸ドット）: sm以上で中央線上に表示 -->
               <div class="hidden sm:block absolute left-1/2 top-6 -translate-x-1/2 w-4 h-4 bg-blue-500 border-4 border-white rounded-full z-20 shadow"></div>
-              <!-- 日付（左側） -->
-              <div class="sm:w-32 text-left sm:pl-8 text-gray-600 flex-shrink-0 mb-2 sm:mb-0">
+              <!-- 日付（中央表示） -->
+              <div class="hidden sm:block absolute left-1/2 top-6 translate-y-6 -translate-x-1/2 text-gray-600 text-sm font-medium z-20">
                 {item.date}
               </div>
               <!-- コンテンツカード（左側） -->
@@ -129,8 +129,8 @@
             <div class="flex flex-col sm:flex-row justify-between mb-8 relative" in:slide={{ duration: 400 }}>
               <!-- インジケーター（丸ドット）: sm以上で中央線上に表示 -->
               <div class="hidden sm:block absolute left-1/2 top-6 -translate-x-1/2 w-4 h-4 bg-blue-500 border-4 border-white rounded-full z-20 shadow"></div>
-              <!-- 日付（右側） -->
-              <div class="sm:w-32 text-right sm:pr-8 text-gray-600 flex-shrink-0 mb-2 sm:mb-0">
+              <!-- 日付（中央表示） -->
+              <div class="hidden sm:block absolute left-1/2 top-6 translate-y-6 -translate-x-1/2 text-gray-600 text-sm font-medium z-20">
                 {item.date}
               </div>
               <!-- コンテンツカード（右側） -->


### PR DESCRIPTION
特定時代フィルタ後のイベントをdateを数値で比較して昇順にソートするように修正しました。